### PR TITLE
Typo in ARMA formula in chapter 4.9

### DIFF
--- a/Lab-intro-to-ts/intro-ts-funcs-lab.Rmd
+++ b/Lab-intro-to-ts/intro-ts-funcs-lab.Rmd
@@ -1392,7 +1392,7 @@ We can write an ARMA($p,q$) as a mixture of AR($p$) and MA($q$) models, such tha
 
 \begin{equation}
 (\#eq:ARMAdefn)
-x_t = \phi_1x_{t-1} + \phi_2x_{t-2} + \dots + \phi_p x_{t-p} + w_t + \theta w_{t-1} + \theta_2 w_{t-2} + \dots + \theta_q x_{t-q},
+x_t = \phi_1x_{t-1} + \phi_2x_{t-2} + \dots + \phi_p x_{t-p} + w_t + \theta_1 w_{t-1} + \theta_2 w_{t-2} + \dots + \theta_q w_{t-q},
 \end{equation}
 
 \noindent and the $w_t$ are white noise.

--- a/docs/sec-tslab-autoregressive-moving-average-arma-models.html
+++ b/docs/sec-tslab-autoregressive-moving-average-arma-models.html
@@ -597,7 +597,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>We can write an ARMA(<span class="math inline">\(p,q\)</span>) as a mixture of AR(<span class="math inline">\(p\)</span>) and MA(<span class="math inline">\(q\)</span>) models, such that</p>
 <p><span class="math display" id="eq:ARMAdefn">\[\begin{equation}
 \tag{4.24}
-x_t = \phi_1x_{t-1} + \phi_2x_{t-2} + \dots + \phi_p x_{t-p} + w_t + \theta w_{t-1} + \theta_2 w_{t-2} + \dots + \theta_q x_{t-q},
+x_t = \phi_1x_{t-1} + \phi_2x_{t-2} + \dots + \phi_p x_{t-p} + w_t + \theta_1 w_{t-1} + \theta_2 w_{t-2} + \dots + \theta_q w_{t-q},
 \end{equation}\]</span></p>
 <p>and the <span class="math inline">\(w_t\)</span> are white noise.</p>
 <div id="sec-tslab-fitting-armapq-models-with-verbarima" class="section level3" number="4.9.1">


### PR DESCRIPTION
The first theta is missing a sub-scripted 1 and the last x should be a w.

As per instructions I edited the Rmd for this section in the Lab- folder AND I made the same edits to the html in the docs folder. 

I hope I made the edits in the correct locations. Please let me know otherwise and I can correct it.